### PR TITLE
Update tencent-auto.json

### DIFF
--- a/Tencent/tencent-auto.json
+++ b/Tencent/tencent-auto.json
@@ -638,6 +638,30 @@
                 "montype":1,
                 "action_type":15,
                 "treatment":3
+            },
+            {
+                "res_path":"*\\Microsoft Shared\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\ListaryHook*.dll",
+                "montype":1,
+                "action_type":2,
+                "treatment":0
+            },
+            {
+                "res_path":"*\\Searches\\*",
+                "montype":1,
+                "action_type":15,
+                "treatment":3
+            },
+            {
+                "res_path":"*\\TPDownloadProxy\\*",
+                "montype":1,
+                "action_type":13,
+                "treatment":3
             }
         ]
     }


### PR DESCRIPTION
TPDownloadProxy文件夹与微信有关，禁用后未发现大问题，如果担心微信存在使用问题，可取消。 The TPDownloadProxy folder is related to WeChat. No major problems are found after disabling it. If you are worried about using WeChat, you can cancel it.